### PR TITLE
Add DB foundation and migrations for persistence

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+sqlalchemy.url = sqlite:///./school.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,48 @@
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from src.db import Base, DATABASE_URL
+from src.models import Activity, Enrollment, User  # noqa: F401
+
+
+config = context.config
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/20260319_0001_create_initial_schema.py
+++ b/alembic/versions/20260319_0001_create_initial_schema.py
@@ -1,0 +1,63 @@
+"""create initial schema
+
+Revision ID: 20260319_0001
+Revises:
+Create Date: 2026-03-19 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260319_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "activities",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.String(length=1000), nullable=False),
+        sa.Column("schedule", sa.String(length=255), nullable=False),
+        sa.Column("max_participants", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_activities_id"), "activities", ["id"], unique=False)
+    op.create_index(op.f("ix_activities_name"), "activities", ["name"], unique=True)
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_users_email"), "users", ["email"], unique=True)
+    op.create_index(op.f("ix_users_id"), "users", ["id"], unique=False)
+
+    op.create_table(
+        "enrollments",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("activity_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["activity_id"], ["activities.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "activity_id", name="uq_user_activity"),
+    )
+    op.create_index(op.f("ix_enrollments_id"), "enrollments", ["id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_enrollments_id"), table_name="enrollments")
+    op.drop_table("enrollments")
+
+    op.drop_index(op.f("ix_users_id"), table_name="users")
+    op.drop_index(op.f("ix_users_email"), table_name="users")
+    op.drop_table("users")
+
+    op.drop_index(op.f("ix_activities_name"), table_name="activities")
+    op.drop_index(op.f("ix_activities_id"), table_name="activities")
+    op.drop_table("activities")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+sqlalchemy
+alembic

--- a/src/README.md
+++ b/src/README.md
@@ -12,13 +12,19 @@ A super simple FastAPI application that allows students to view and sign up for 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn src.app:app --reload
+   ```
+
+3. (Optional but recommended) run migrations before starting:
+
+   ```
+   alembic upgrade head
    ```
 
 3. Open your browser and go to:
@@ -47,4 +53,5 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+The project now includes database models and migrations for persistence work.
+The current API behavior remains unchanged while persistence is being rolled out incrementally.

--- a/src/app.py
+++ b/src/app.py
@@ -11,6 +11,9 @@ from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
 
+from src.db import SessionLocal, init_db
+from src.models import Activity, Enrollment, User
+
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
@@ -76,6 +79,55 @@ activities = {
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
 }
+
+
+def seed_initial_data() -> None:
+    db = SessionLocal()
+    try:
+        existing_activities = db.query(Activity).count()
+        if existing_activities > 0:
+            return
+
+        users_by_email = {}
+        for activity_name, activity in activities.items():
+            activity_model = Activity(
+                name=activity_name,
+                description=activity["description"],
+                schedule=activity["schedule"],
+                max_participants=activity["max_participants"],
+            )
+            db.add(activity_model)
+            db.flush()
+
+            for email in activity["participants"]:
+                user_model = users_by_email.get(email)
+                if user_model is None:
+                    user_model = db.query(User).filter(User.email == email).first()
+                    if user_model is None:
+                        user_model = User(email=email)
+                        db.add(user_model)
+                        db.flush()
+                    users_by_email[email] = user_model
+
+                db.add(
+                    Enrollment(
+                        user_id=user_model.id,
+                        activity_id=activity_model.id,
+                    )
+                )
+
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+    seed_initial_data()
 
 
 @app.get("/")

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,19 @@
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./school.db")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def init_db() -> None:
+    from src.models import Activity, Enrollment, User  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from src.db import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String(255), unique=True, nullable=False, index=True)
+
+    enrollments = relationship("Enrollment", back_populates="user", cascade="all, delete-orphan")
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), unique=True, nullable=False, index=True)
+    description = Column(String(1000), nullable=False)
+    schedule = Column(String(255), nullable=False)
+    max_participants = Column(Integer, nullable=False)
+
+    enrollments = relationship("Enrollment", back_populates="activity", cascade="all, delete-orphan")
+
+
+class Enrollment(Base):
+    __tablename__ = "enrollments"
+    __table_args__ = (UniqueConstraint("user_id", "activity_id", name="uq_user_activity"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    activity_id = Column(Integer, ForeignKey("activities.id", ondelete="CASCADE"), nullable=False)
+
+    user = relationship("User", back_populates="enrollments")
+    activity = relationship("Activity", back_populates="enrollments")


### PR DESCRIPTION
## Summary
- add SQLAlchemy DB setup and models for users, activities, and enrollments
- add Alembic configuration and baseline migration
- initialize and seed DB on app startup while preserving current API behavior
- update dependencies and README setup steps

## Validation
- diagnostics report no errors in changed files
- `alembic upgrade head` currently requires environment package install (`alembic` not found in this container runtime)